### PR TITLE
Support embeddings and TTS endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,22 @@ curl "http://127.0.0.1:3017/partition/$USER/instance/reservoir/v1/chat/completio
     }'
 ```
 
+**Embeddings:**
+```bash
+curl "http://127.0.0.1:3017/v1/embeddings" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -d '{"model": "text-embedding-ada-002", "input": "hello world"}'
+```
+
+**Text to Speech:**
+```bash
+curl "http://127.0.0.1:3017/v1/audio/speech" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $OPENAI_API_KEY" \
+    -d '{"model": "tts-1", "input": "hello", "voice": "alloy", "response_format": "mp3", "speed": 1.0}'
+```
+
 #### Python Examples (using `openai` library)
 
 **Basic Usage with OpenAI:**

--- a/src/clients/openai/mod.rs
+++ b/src/clients/openai/mod.rs
@@ -2,3 +2,4 @@ pub mod chat_completions;
 pub mod embeddings;
 pub mod model_info;
 pub mod types;
+pub mod tts;

--- a/src/clients/openai/model_info.rs
+++ b/src/clients/openai/model_info.rs
@@ -1,12 +1,51 @@
 use std::env;
 
 const RSV_OPENAI_BASE_URL: &str = "RSV_OPENAI_BASE_URL";
+const OPENAI_BASE_URL: &str = "OPENAI_BASE_URL";
 const RSV_OLLAMA_BASE_URL: &str = "RSV_OLLAMA_BASE_URL";
 const RSV_MISTRAL_BASE_URL: &str = "RSV_MISTRAL_BASE_URL";
 
+fn base_host() -> String {
+    env::var(OPENAI_BASE_URL)
+        .or_else(|_| env::var(RSV_OPENAI_BASE_URL))
+        .unwrap_or_else(|_| "https://api.openai.com".to_string())
+}
+
+fn completions_url() -> String {
+    let base = base_host();
+    if base.contains("/chat/completions") {
+        base
+    } else if base.ends_with("/v1") || base.ends_with("/v1/") {
+        format!("{}/chat/completions", base.trim_end_matches('/'))
+    } else {
+        format!("{}/v1/chat/completions", base.trim_end_matches('/'))
+    }
+}
+
+pub fn openai_embeddings_url() -> String {
+    let base = base_host();
+    if base.contains("/embeddings") {
+        base
+    } else if base.ends_with("/v1") || base.ends_with("/v1/") {
+        format!("{}/embeddings", base.trim_end_matches('/'))
+    } else {
+        format!("{}/v1/embeddings", base.trim_end_matches('/'))
+    }
+}
+
+pub fn openai_tts_url() -> String {
+    let base = base_host();
+    if base.contains("/audio/speech") {
+        base
+    } else if base.ends_with("/v1") || base.ends_with("/v1/") {
+        format!("{}/audio/speech", base.trim_end_matches('/'))
+    } else {
+        format!("{}/v1/audio/speech", base.trim_end_matches('/'))
+    }
+}
+
 fn openai_base_url() -> String {
-    env::var(RSV_OPENAI_BASE_URL)
-        .unwrap_or_else(|_| "https://api.openai.com/v1/chat/completions".to_string())
+    completions_url()
 }
 
 fn ollama_base_url() -> String {

--- a/src/clients/openai/tts.rs
+++ b/src/clients/openai/tts.rs
@@ -1,0 +1,37 @@
+use anyhow::Error;
+use bytes::Bytes;
+use http::{header, Method, Request, Uri};
+use http_body_util::{BodyExt, Full};
+use hyper_tls::HttpsConnector;
+use hyper::Client;
+use std::env;
+use tracing::error;
+
+use super::model_info::openai_tts_url;
+
+pub async fn call_tts_endpoint(body: Bytes) -> Result<Bytes, Error> {
+    let https = HttpsConnector::new();
+    let client: Client<_, _> = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+
+    let api_key = env::var("OPENAI_API_KEY").unwrap_or_default();
+    let url = openai_tts_url();
+    let uri: Uri = url.parse()?;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {}", api_key))
+        .body(Full::new(body))?;
+
+    let resp = client.request(req).await?;
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await?.to_bytes();
+
+    if !status.is_success() {
+        let text = String::from_utf8_lossy(&bytes);
+        error!("TTS request error {}: {}", status, text);
+        return Err(Error::msg(format!("TTS API error {}: {}", status, text)));
+    }
+    Ok(bytes)
+}

--- a/src/handler/embeddings.rs
+++ b/src/handler/embeddings.rs
@@ -1,0 +1,36 @@
+use anyhow::Error;
+use bytes::Bytes;
+use http::{header, Method, Request, Uri};
+use http_body_util::{BodyExt, Full};
+use hyper_tls::HttpsConnector;
+use hyper::Client;
+use std::env;
+use tracing::error;
+
+use crate::clients::openai::model_info::openai_embeddings_url;
+
+pub async fn handle_embeddings(body: Bytes) -> Result<Bytes, Error> {
+    let https = HttpsConnector::new();
+    let client: Client<_, _> = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+
+    let api_key = env::var("OPENAI_API_KEY").unwrap_or_default();
+    let url = openai_embeddings_url();
+    let uri: Uri = url.parse()?;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {}", api_key))
+        .body(Full::new(body))?;
+
+    let resp = client.request(req).await?;
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await?.to_bytes();
+
+    if !status.is_success() {
+        let text = String::from_utf8_lossy(&bytes);
+        error!("Embeddings error {}: {}", status, text);
+        return Err(Error::msg(format!("Embeddings API error {}: {}", status, text)));
+    }
+    Ok(bytes)
+}

--- a/src/handler/mod.rs
+++ b/src/handler/mod.rs
@@ -1,1 +1,3 @@
 pub mod completions;
+pub mod embeddings;
+pub mod tts;

--- a/src/handler/tts.rs
+++ b/src/handler/tts.rs
@@ -1,0 +1,36 @@
+use anyhow::Error;
+use bytes::Bytes;
+use http::{header, Method, Request, Uri};
+use http_body_util::{BodyExt, Full};
+use hyper_tls::HttpsConnector;
+use hyper::Client;
+use std::env;
+use tracing::error;
+
+use crate::clients::openai::model_info::openai_tts_url;
+
+pub async fn handle_tts(body: Bytes) -> Result<Bytes, Error> {
+    let https = HttpsConnector::new();
+    let client: Client<_, _> = hyper_util::client::legacy::Client::builder(hyper_util::rt::TokioExecutor::new()).build(https);
+
+    let api_key = env::var("OPENAI_API_KEY").unwrap_or_default();
+    let url = openai_tts_url();
+    let uri: Uri = url.parse()?;
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri(uri)
+        .header(header::CONTENT_TYPE, "application/json")
+        .header(header::AUTHORIZATION, format!("Bearer {}", api_key))
+        .body(Full::new(body))?;
+
+    let resp = client.request(req).await?;
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await?.to_bytes();
+
+    if !status.is_success() {
+        let text = String::from_utf8_lossy(&bytes);
+        error!("TTS error {}: {}", status, text);
+        return Err(Error::msg(format!("TTS API error {}: {}", status, text)));
+    }
+    Ok(bytes)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ use commands::search::execute as search_execute;
 use commands::search::SearchOptions;
 use commands::view::execute;
 use handler::completions::handle_with_partition;
+use handler::embeddings::handle_embeddings;
+use handler::tts::handle_tts;
 use http_body_util::BodyExt;
 use http_body_util::Full;
 use hyper::body::Bytes;
@@ -41,6 +43,14 @@ fn get_instance_from_path(path: &str) -> Option<String> {
 
 fn is_chat_request(path: &str) -> bool {
     path.contains("/chat/completions")
+}
+
+fn is_embeddings_request(path: &str) -> bool {
+    path.ends_with("/embeddings")
+}
+
+fn is_tts_request(path: &str) -> bool {
+    path.contains("/audio/speech")
 }
 
 fn is_search_request(path: &str) -> bool {
@@ -84,6 +94,28 @@ async fn handle(req: Request<Incoming>) -> Result<Response<Full<Bytes>>, Infalli
                 }
             };
             Ok(Response::new(Full::new(response_bytes)))
+        }
+
+        (&Method::POST, path) if is_embeddings_request(path) => {
+            let whole_body = req.into_body().collect().await.unwrap().to_bytes();
+            match handle_embeddings(whole_body).await {
+                Ok(bytes) => Ok(Response::new(Full::new(bytes))),
+                Err(e) => {
+                    error!("Error handling embeddings: {}", e);
+                    Ok(Response::new(Full::new(Bytes::from("Embeddings Error"))))
+                }
+            }
+        }
+
+        (&Method::POST, path) if is_tts_request(path) => {
+            let whole_body = req.into_body().collect().await.unwrap().to_bytes();
+            match handle_tts(whole_body).await {
+                Ok(bytes) => Ok(Response::new(Full::new(bytes))),
+                Err(e) => {
+                    error!("Error handling tts: {}", e);
+                    Ok(Response::new(Full::new(Bytes::from("TTS Error"))))
+                }
+            }
         }
 
         (&Method::POST, "/echo") => {


### PR DESCRIPTION
## Summary
- add /v1/embeddings and /v1/audio/speech endpoints
- implement forwarding handlers for embeddings and text-to-speech
- expose helper URLs that respect OPENAI_BASE_URL
- include curl examples for embeddings and TTS in README

## Testing
- `cargo check` *(fails: invalid peer certificate for onnxruntime download)*

------
https://chatgpt.com/codex/tasks/task_e_6855b45f8658833193583c65e7558f27